### PR TITLE
feat: add client alpn extension

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -39,7 +39,9 @@ impl<A> ShadowTlsClient<A> {
             .with_root_certificates(root_store)
             .with_no_client_auth();
         // Set ALPN
-        tls_config.alpn_protocols = vec![alpn.as_bytes().to_vec()];
+        if alpn.len() != 0 {
+            tls_config.alpn_protocols = vec![alpn.as_bytes().to_vec()];
+        }
 
         let tls_connector = TlsConnector::from(tls_config);
         let server_name = ServerName::try_from(server_name)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,7 @@ enum Commands {
         password: String,
         #[clap(
             long = "alpn",
+            default_value = "",
             help = "Application-Layer Protocol Negotiation(like \"http/1.1\")"
         )]
         alpn: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,11 @@ enum Commands {
         tls_name: String,
         #[clap(long = "password", help = "Password")]
         password: String,
+        #[clap(
+            long = "alpn",
+            help = "Application-Layer Protocol Negotiation(like \"http/1.1\")"
+        )]
+        alpn: String,
     },
     #[clap(about = "Run server side")]
     Server {
@@ -118,12 +123,14 @@ async fn run(cli: Arc<Args>) {
             server_addr,
             tls_name,
             password,
+            alpn,
         } => {
             run_client(
                 listen.clone(),
                 server_addr.clone(),
                 tls_name.clone(),
                 password.clone(),
+                alpn.clone(),
             )
             .await
             .expect("client exited");
@@ -151,9 +158,15 @@ async fn run_client(
     server_addr: String,
     tls_name: String,
     password: String,
+    alpn: String,
 ) -> anyhow::Result<()> {
     info!("Client is running!\nListen address: {listen}\nRemote address: {server_addr}\nTLS server name: {tls_name}");
-    let shadow_client = Rc::new(ShadowTlsClient::new(&tls_name, server_addr, password)?);
+    let shadow_client = Rc::new(ShadowTlsClient::new(
+        &tls_name,
+        server_addr,
+        password,
+        alpn,
+    )?);
     let listener = TcpListener::bind(&listen)?;
     loop {
         match listener.accept().await {

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,9 @@ use monoio::net::TcpListener;
 use tracing::{error, info};
 use tracing_subscriber::{filter::LevelFilter, fmt, prelude::*, EnvFilter};
 
-use crate::{client::ShadowTlsClient, server::ShadowTlsServer, util::set_tcp_keepalive};
+use crate::{
+    client::ShadowTlsClient, client::TlsExtConfig, server::ShadowTlsServer, util::set_tcp_keepalive,
+};
 
 #[derive(Parser, Debug)]
 #[clap(
@@ -166,7 +168,7 @@ async fn run_client(
         &tls_name,
         server_addr,
         password,
-        alpn,
+        TlsExtConfig::new(vec![alpn.into()]),
     )?);
     let listener = TcpListener::bind(&listen)?;
     loop {


### PR DESCRIPTION
In most of time, when you send client hello to server while viewing website, client will set alpn. This PR get alpn from args, and set alpn in `tls_config`.