### PR TITLE
feat: use simd in xor

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(impl_trait_in_assoc_type)]
+#![feature(portable_simd)]
 
 mod client;
 mod helper_v2;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,9 @@
 use std::{
-    io::{ErrorKind, Read}, net::ToSocketAddrs, ptr::copy_nonoverlapping, simd::Simd, time::Duration
+    io::{ErrorKind, Read},
+    net::ToSocketAddrs,
+    ptr::copy_nonoverlapping,
+    simd::Simd,
+    time::Duration,
 };
 
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
@@ -164,7 +168,11 @@ impl Hmac {
 
 #[inline]
 pub(crate) fn xor_slice(data: &mut [u8], key: &[u8]) {
-    xor_slice_simd(data, key);
+    if 32 % key.len() == 0 {
+        xor_slice_simd(data, key);
+    } else {
+        xor_slice_legacy(data, key);
+    }
 }
 
 #[allow(unused)]


### PR DESCRIPTION
introduces SIMD (Single Instruction, Multiple Data) for enhancing performance of xor operations.
the detailed benchmark and test code can be found in [this gist](https://gist.github.com/hsqStephenZhang/59d5064078bd60bdfea1a33de04ab2ec)

```bash
legacy                  time:   [1.3048 ms 1.3050 ms 1.3053 ms]
                        change: [-0.3654% -0.1833% -0.0463%] (p = 0.01 < 0.05)
                        Change within noise threshold.

simd                    time:   [94.954 µs 95.252 µs 95.541 µs]
                        change: [+0.5827% +0.9576% +1.3364%] (p = 0.00 < 0.05)
                        Change within noise threshold.
```

it's basically ok to use simd32, since the key derived by kdf is 32 bytes long.